### PR TITLE
Lpfg 679 cancel event

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/api/EventController.java
+++ b/src/main/java/uk/gov/cslearning/record/api/EventController.java
@@ -20,8 +20,9 @@ public class EventController {
 
     @PatchMapping(path = "/event/{eventUid}")
     public ResponseEntity cancelEvent(@PathVariable String eventUid, @RequestBody EventStatusDto eventStatus) {
-        EventDto event = eventService.updateStatus(eventUid, eventStatus);
-        return ResponseEntity.ok(event);
+        return eventService.updateStatus(eventUid, eventStatus).
+            map(e -> new ResponseEntity(e, OK))
+            .orElseGet(() -> new ResponseEntity(NOT_FOUND));
     }
 
     @GetMapping(path = "/event/{eventUid}")

--- a/src/main/java/uk/gov/cslearning/record/domain/Event.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/Event.java
@@ -4,6 +4,7 @@ package uk.gov.cslearning.record.domain;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import uk.gov.cslearning.record.dto.CancellationReason;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -29,4 +30,7 @@ public class Event {
     @ToString.Exclude
     @OneToMany(mappedBy = "event")
     private List<Booking> bookings = new ArrayList<>();
+
+    @Column(nullable = false)
+    private CancellationReason cancellationReason;
 }

--- a/src/main/java/uk/gov/cslearning/record/domain/factory/EventFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/factory/EventFactory.java
@@ -27,6 +27,7 @@ public class EventFactory {
         event.setPath(path);
         event.setUid(Paths.get(path).getFileName().toString());
         event.setStatus(eventDto.getStatus().getValue());
+        event.setCancellationReason(eventDto.getCancellationReason());
         return event;
     }
 

--- a/src/main/java/uk/gov/cslearning/record/dto/CancellationReason.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/CancellationReason.java
@@ -1,0 +1,30 @@
+package uk.gov.cslearning.record.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import uk.gov.cslearning.record.exception.UnknownStatusException;
+
+import java.util.Arrays;
+
+public enum CancellationReason {
+    UNAVAILABLE("Unavailable"),VENUE("Venue");
+
+    private final String value;
+
+    CancellationReason(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static CancellationReason forValue(String value) {
+        return Arrays.stream(CancellationReason.values())
+                .filter(v -> v.value.equalsIgnoreCase(value))
+                .findAny()
+                .orElseThrow(() -> new UnknownStatusException(value));
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/cslearning/record/dto/EventDto.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/EventDto.java
@@ -12,4 +12,5 @@ public class EventDto {
     private String uid;
     private URI uri;
     private EventStatus status;
+    private CancellationReason cancellationReason;
 }

--- a/src/main/java/uk/gov/cslearning/record/dto/EventStatusDto.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/EventStatusDto.java
@@ -11,4 +11,6 @@ import uk.gov.cslearning.record.validation.annotations.EventStatusNotEquals;
 public class EventStatusDto {
     @EventStatusNotEquals(value = EventStatus.ACTIVE, message = "{event.status.invalid}")
     private EventStatus status;
+
+    private String cancellationReason;
 }

--- a/src/main/java/uk/gov/cslearning/record/service/DefaultEventService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/DefaultEventService.java
@@ -2,6 +2,7 @@ package uk.gov.cslearning.record.service;
 
 import org.springframework.stereotype.Service;
 import uk.gov.cslearning.record.domain.Event;
+import uk.gov.cslearning.record.dto.CancellationReason;
 import uk.gov.cslearning.record.dto.EventDto;
 import uk.gov.cslearning.record.dto.EventStatus;
 import uk.gov.cslearning.record.dto.EventStatusDto;
@@ -48,6 +49,12 @@ public class DefaultEventService implements EventService {
 
         EventDto eventDto = eventDtoFactory.create(event);
         eventDto.setStatus(eventStatus.getStatus());
+
+        if(eventStatus.getCancellationReason().equals("Short notice unavailability of the venue")){
+            eventDto.setCancellationReason(CancellationReason.VENUE);
+        } else if(eventStatus.getCancellationReason().equals("The event is no longer available")){
+            eventDto.setCancellationReason(CancellationReason.UNAVAILABLE);
+        }
 
         return Optional.of(eventDtoFactory.create(eventRepository.save(eventFactory.create(eventDto))));
     }

--- a/src/main/java/uk/gov/cslearning/record/service/DefaultEventService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/DefaultEventService.java
@@ -39,7 +39,7 @@ public class DefaultEventService implements EventService {
     }
 
     @Override
-    public EventDto updateStatus(String eventUid, EventStatusDto eventStatus) {
+    public Optional<EventDto> updateStatus(String eventUid, EventStatusDto eventStatus) {
         Event event = eventRepository.findByUid(eventUid).orElseThrow(() -> new EventNotFoundException(eventUid));
 
         if (eventStatus.getStatus().equals(EventStatus.CANCELLED)) {
@@ -49,7 +49,7 @@ public class DefaultEventService implements EventService {
         EventDto eventDto = eventDtoFactory.create(event);
         eventDto.setStatus(eventStatus.getStatus());
 
-        return eventDtoFactory.create(eventRepository.save(eventFactory.create(eventDto)));
+        return Optional.of(eventDtoFactory.create(eventRepository.save(eventFactory.create(eventDto))));
     }
 
     @Override

--- a/src/main/java/uk/gov/cslearning/record/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/EventService.java
@@ -13,7 +13,7 @@ public interface EventService {
     Event getEvent(String eventUid, String path);
 
     @Transactional
-    EventDto updateStatus(String eventUid, EventStatusDto eventStatus);
+    Optional<EventDto> updateStatus(String eventUid, EventStatusDto eventStatus);
 
     @Transactional(readOnly = true)
     Optional<EventDto> findByUid(String eventUid);

--- a/src/main/resources/db/migration/h2/V1.1.8__add-cancellation-reason.sql
+++ b/src/main/resources/db/migration/h2/V1.1.8__add-cancellation-reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD `cancellation_reason` enum('UNAVAILABLE', 'VENUE') DEFAULT NULL;

--- a/src/main/resources/db/migration/mysql/V1.1.8__add-cancellation-reason.sql
+++ b/src/main/resources/db/migration/mysql/V1.1.8__add-cancellation-reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD `cancellation_reason` enum('UNAVAILABLE', 'VENUE') DEFAULT NULL;

--- a/src/test/java/uk/gov/cslearning/record/api/EventControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/record/api/EventControllerTest.java
@@ -89,7 +89,7 @@ public class EventControllerTest {
         event.setUid(eventUid);
         event.setUri(uri);
 
-        when(eventService.updateStatus(eventUid, eventStatusDto)).thenReturn(event);
+        when(eventService.updateStatus(eventUid, eventStatusDto)).thenReturn(Optional.of(event));
 
         mockMvc.perform(
                 patch("/event/" + eventUid).with(csrf())

--- a/src/test/java/uk/gov/cslearning/record/api/EventControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/record/api/EventControllerTest.java
@@ -82,7 +82,7 @@ public class EventControllerTest {
         String eventUid = "event-id";
         URI uri = URI.create("http://localhost:9001/courses/course-id/modules/module-id/events/event-id");
 
-        EventStatusDto eventStatusDto = new EventStatusDto(EventStatus.CANCELLED);
+        EventStatusDto eventStatusDto = new EventStatusDto(EventStatus.CANCELLED, "");
 
         EventDto event = new EventDto();
         event.setStatus(EventStatus.CANCELLED);
@@ -107,7 +107,7 @@ public class EventControllerTest {
     @Test
     public void shouldReturnNotFoundIfEventNotFoundOnPatch() throws Exception {
         String eventUid = "event-id";
-        EventStatusDto eventStatus = new EventStatusDto(EventStatus.CANCELLED);
+        EventStatusDto eventStatus = new EventStatusDto(EventStatus.CANCELLED, "");
 
         EventNotFoundException exception = mock(EventNotFoundException.class);
 

--- a/src/test/java/uk/gov/cslearning/record/service/DefaultEventServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/DefaultEventServiceTest.java
@@ -121,7 +121,7 @@ public class DefaultEventServiceTest {
         when(eventRepository.save(updatedEvent)).thenReturn(savedEvent);
         when(eventDtoFactory.create(savedEvent)).thenReturn(savedEventDto);
 
-        assertEquals(savedEventDto, eventService.updateStatus(eventUid, new EventStatusDto(EventStatus.CANCELLED)));
+        assertEquals(Optional.of(savedEventDto), eventService.updateStatus(eventUid, new EventStatusDto(EventStatus.CANCELLED)));
 
         verify(eventDto).setStatus(EventStatus.CANCELLED);
         verify(bookingService).unregister(booking1);

--- a/src/test/java/uk/gov/cslearning/record/service/DefaultEventServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/DefaultEventServiceTest.java
@@ -78,7 +78,7 @@ public class DefaultEventServiceTest {
         when(eventRepository.findByUid(eventUid)).thenReturn(Optional.empty());
 
         try {
-            eventService.updateStatus(eventUid, new EventStatusDto(EventStatus.CANCELLED));
+            eventService.updateStatus(eventUid, new EventStatusDto(EventStatus.CANCELLED, ""));
             fail("Expected EventNotFoundException");
         } catch (EventNotFoundException e) {
             assertEquals("Event does not exist with catalogue id: " + eventUid, e.getMessage());
@@ -121,7 +121,7 @@ public class DefaultEventServiceTest {
         when(eventRepository.save(updatedEvent)).thenReturn(savedEvent);
         when(eventDtoFactory.create(savedEvent)).thenReturn(savedEventDto);
 
-        assertEquals(Optional.of(savedEventDto), eventService.updateStatus(eventUid, new EventStatusDto(EventStatus.CANCELLED)));
+        assertEquals(Optional.of(savedEventDto), eventService.updateStatus(eventUid, new EventStatusDto(EventStatus.CANCELLED, "")));
 
         verify(eventDto).setStatus(EventStatus.CANCELLED);
         verify(bookingService).unregister(booking1);


### PR DESCRIPTION
An update to the cancel event endpoint to allow for events with no attendees, which therefor don't exist on the learner-record.

EventController.java: cancelEvent now returns not found if the event doesn't exist
EventStatusDto.java: added cancellationReason
EventService.java: updateStatus returns Optional of eventDto, empty if no event exists
