### PR TITLE
LPFG-1065: Delete cancelled booking when new booking is booked

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/repository/BookingRepository.java
+++ b/src/main/java/uk/gov/cslearning/record/repository/BookingRepository.java
@@ -1,10 +1,13 @@
 package uk.gov.cslearning.record.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.cslearning.record.domain.Booking;
+import uk.gov.cslearning.record.domain.Event;
+import uk.gov.cslearning.record.domain.Learner;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +19,8 @@ public interface BookingRepository extends CrudRepository<Booking, Integer>, Cus
 
     @Query("select b from Booking b where b.event.uid = :eventUid and b.learner.uid = :learnerUid")
     Optional<Booking> findByEventUidLearnerUid(@Param("eventUid") String eventUid, @Param("learnerUid") String learnerUid);
+
+    @Modifying
+    @Query("delete from Booking b where b = :booking and b.status in :status")
+    void deleteBookingWithStatus(@Param("booking") Booking booking, @Param("status") List<String> status);
 }


### PR DESCRIPTION
If a user books onto an event and a booking already exists in the database and it's status is cancelled, the booking will be deleted, so as to allow a new booking to be added to the database without violating the unique learner_uid event_uid key constraint.

Currently if a user books, cancels their booking and rebooks onto the same event, an error occurs due to the unique key constraint in the learner record db. 