### PR TITLE
LPFG-998: Courses Still Appears After Feedback

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/service/xapi/StatementStream.java
+++ b/src/main/java/uk/gov/cslearning/record/service/xapi/StatementStream.java
@@ -147,9 +147,7 @@ public class StatementStream {
                             }
                         }
 
-                        if(moduleRecord.getState() != State.COMPLETED) {
-                            replay(statement, courseRecord, moduleRecord);
-                        }
+                        replay(statement, courseRecord, moduleRecord);
 
                         if (checkComplete(courseRecord, catalogueCourse)) {
                             courseRecord.setState(State.COMPLETED);

--- a/src/main/java/uk/gov/cslearning/record/service/xapi/action/InitialisedAction.java
+++ b/src/main/java/uk/gov/cslearning/record/service/xapi/action/InitialisedAction.java
@@ -23,10 +23,12 @@ public class InitialisedAction extends Action {
 
     @Override
     public void replay(CourseRecord courseRecord, ModuleRecord moduleRecord) {
-        courseRecord.setState(State.IN_PROGRESS);
-        moduleRecord.setState(State.IN_PROGRESS);
-        moduleRecord.setResult(null);
-        moduleRecord.setScore(null);
-        moduleRecord.setCompletionDate(null);
+        if(moduleRecord.getState() != State.COMPLETED) {
+            courseRecord.setState(State.IN_PROGRESS);
+            moduleRecord.setState(State.IN_PROGRESS);
+            moduleRecord.setResult(null);
+            moduleRecord.setScore(null);
+            moduleRecord.setCompletionDate(null);
+        }
     }
 }


### PR DESCRIPTION
Currently when a learner gives feedback on a course, the course still appears as ready for feedback.

This is because a fix was made to learner record to stop any actions being registered on a module once it's completed. This was done because once a user had completed an E-Learning module, if they carried out any other actions the state of the module would be set back to 'In Progress'. This also means that a 'rated' action can't be performed after the module is completed, which causes the current problem.

This fix moves the completed check to InitialisedAction.java, so that the state can't be set to 'In Progress' once the module is completed, but it can be 'rated' and other things that happen after module completion. 