### PR TITLE
LPFG-1089: Added PO number to booking

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/domain/Booking.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/Booking.java
@@ -30,4 +30,7 @@ public class Booking {
     private String status;
 
     private Instant bookingTime;
+
+    @Column
+    private String poNumber;
 }

--- a/src/main/java/uk/gov/cslearning/record/domain/factory/BookingFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/factory/BookingFactory.java
@@ -27,6 +27,7 @@ public class BookingFactory {
         booking.setLearner(learnerFactory.create(bookingDto.getLearner(), bookingDto.getLearnerEmail()));
         booking.setId(bookingDto.getId());
         booking.setStatus(bookingDto.getStatus().getValue());
+        booking.setPoNumber(bookingDto.getPoNumber());
 
         return booking;
     }

--- a/src/main/java/uk/gov/cslearning/record/dto/BookingDto.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/BookingDto.java
@@ -29,4 +29,6 @@ public class BookingDto {
     private Instant bookingTime = Instant.now();
 
     private URI paymentDetails;
+
+    private String poNumber;
 }

--- a/src/main/java/uk/gov/cslearning/record/dto/factory/BookingDtoFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/factory/BookingDtoFactory.java
@@ -27,6 +27,7 @@ public class BookingDtoFactory {
         bookingDto.setLearner(booking.getLearner().getUid());
         bookingDto.setLearnerEmail(booking.getLearner().getLearnerEmail());
         bookingDto.setBookingTime(booking.getBookingTime());
+        bookingDto.setPoNumber(booking.getPoNumber());
 
         if (null != booking.getPaymentDetails()) {
             bookingDto.setPaymentDetails(UriBuilder.fromUri(csrsBaseUrl).path(booking.getPaymentDetails()).build());

--- a/src/main/java/uk/gov/cslearning/record/service/xapi/factory/StatementFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/service/xapi/factory/StatementFactory.java
@@ -24,16 +24,18 @@ public class StatementFactory {
     public Statement createRegisteredStatement(BookingDto bookingDto) {
         Actor actor = actorFactory.create(bookingDto.getLearner());
 
-        Result result = resultFactory.createPurchaseOrderResult(bookingDto.getPaymentDetails().toString());
-
         IStatementObject object = objectFactory.createEventObject(bookingDto.getEvent().toString());
 
         Statement statement = new Statement();
         statement.setActor(actor);
         statement.setVerb(verbFactory.createdRegistered());
         statement.setObject(object);
-        statement.setResult(result);
         statement.setContext(contextFactory.createBookingContext(bookingDto));
+
+        if(bookingDto.getPaymentDetails() != null) {
+            Result result = resultFactory.createPurchaseOrderResult(bookingDto.getPaymentDetails().toString());
+            statement.setResult(result);
+        }
 
         return statement;
     }

--- a/src/main/resources/db/migration/h2/V1.1.10__add-po-number-to-booking.sql
+++ b/src/main/resources/db/migration/h2/V1.1.10__add-po-number-to-booking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE booking ADD `po_number` VARCHAR(60);

--- a/src/main/resources/db/migration/mysql/V1.1.10__add-po-number-to-booking.sql
+++ b/src/main/resources/db/migration/mysql/V1.1.10__add-po-number-to-booking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE booking ADD `po_number` VARCHAR(60);


### PR DESCRIPTION
**Should be merged after LPFG-1065 as that has the db V.1.1.9**

Currently a learner who has entered their PO number manually can't have their booking status changed, because the process for doing so checks for a bulk PO number, which are not set if the learner enters a PO number manually.

This stores a PO number if a learner enters it manually, so that it can be displayed and manually confirmed in managment. It also stops a null pointer exception occurring in StatementFactory.java by only adding a purchase order result if a purchase order is set in the booking.

 