### PR TITLE
Lpfg 669 event status

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/api/EventController.java
+++ b/src/main/java/uk/gov/cslearning/record/api/EventController.java
@@ -2,6 +2,7 @@ package uk.gov.cslearning.record.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.cslearning.record.dto.EventDto;
 import uk.gov.cslearning.record.dto.EventStatusDto;
 import uk.gov.cslearning.record.service.EventService;
@@ -32,4 +33,12 @@ public class EventController {
                 .orElseGet(() -> new ResponseEntity<>(NOT_FOUND));
     }
 
+    @PostMapping(path = "/event")
+    public ResponseEntity<EventDto> find(@RequestBody EventDto event, UriComponentsBuilder uriBuilder) {
+        EventDto result = eventService.create(event);
+
+        return ResponseEntity.created(
+                uriBuilder.path("/event/{eventId}").build(result.getUid())
+        ).build();
+    }
 }

--- a/src/main/java/uk/gov/cslearning/record/api/EventController.java
+++ b/src/main/java/uk/gov/cslearning/record/api/EventController.java
@@ -34,7 +34,7 @@ public class EventController {
     }
 
     @PostMapping(path = "/event")
-    public ResponseEntity<EventDto> find(@RequestBody EventDto event, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<EventDto> create(@RequestBody EventDto event, UriComponentsBuilder uriBuilder) {
         EventDto result = eventService.create(event);
 
         return ResponseEntity.created(

--- a/src/main/java/uk/gov/cslearning/record/domain/Booking.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/Booking.java
@@ -2,6 +2,7 @@ package uk.gov.cslearning.record.domain;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.cslearning.record.dto.BookingStatus;
 
 import javax.persistence.*;
 import java.time.Instant;
@@ -28,7 +29,7 @@ public class Booking {
 
     @Column(nullable = false, length = 9)
     @Enumerated(EnumType.STRING)
-    private String status;
+    private BookingStatus status;
 
     private Instant bookingTime;
 

--- a/src/main/java/uk/gov/cslearning/record/domain/Booking.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/Booking.java
@@ -27,6 +27,7 @@ public class Booking {
     private String paymentDetails;
 
     @Column(nullable = false, length = 9)
+    @Enumerated(EnumType.STRING)
     private String status;
 
     private Instant bookingTime;

--- a/src/main/java/uk/gov/cslearning/record/domain/Event.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/Event.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import uk.gov.cslearning.record.dto.CancellationReason;
+import uk.gov.cslearning.record.dto.EventStatus;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ public class Event {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private String status;
+    private EventStatus status;
 
     @ToString.Exclude
     @OneToMany(mappedBy = "event")

--- a/src/main/java/uk/gov/cslearning/record/domain/Event.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/Event.java
@@ -25,6 +25,7 @@ public class Event {
     private String path;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private String status;
 
     @ToString.Exclude
@@ -32,5 +33,6 @@ public class Event {
     private List<Booking> bookings = new ArrayList<>();
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private CancellationReason cancellationReason;
 }

--- a/src/main/java/uk/gov/cslearning/record/domain/factory/BookingFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/factory/BookingFactory.java
@@ -26,7 +26,7 @@ public class BookingFactory {
 
         booking.setLearner(learnerFactory.create(bookingDto.getLearner(), bookingDto.getLearnerEmail()));
         booking.setId(bookingDto.getId());
-        booking.setStatus(bookingDto.getStatus().getValue());
+        booking.setStatus(bookingDto.getStatus());
         booking.setPoNumber(bookingDto.getPoNumber());
 
         return booking;

--- a/src/main/java/uk/gov/cslearning/record/domain/factory/EventFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/domain/factory/EventFactory.java
@@ -5,7 +5,6 @@ import uk.gov.cslearning.record.domain.Event;
 import uk.gov.cslearning.record.dto.EventDto;
 import uk.gov.cslearning.record.dto.EventStatus;
 
-import java.net.URI;
 import java.nio.file.Paths;
 
 @Component
@@ -15,7 +14,7 @@ public class EventFactory {
         Event event = new Event();
         event.setPath(path);
         event.setUid(Paths.get(path).getFileName().toString());
-        event.setStatus(EventStatus.ACTIVE.getValue());
+        event.setStatus(EventStatus.ACTIVE);
         return event;
     }
 
@@ -26,7 +25,7 @@ public class EventFactory {
         event.setId(eventDto.getId());
         event.setPath(path);
         event.setUid(Paths.get(path).getFileName().toString());
-        event.setStatus(eventDto.getStatus().getValue());
+        event.setStatus(eventDto.getStatus());
         event.setCancellationReason(eventDto.getCancellationReason());
         return event;
     }

--- a/src/main/java/uk/gov/cslearning/record/dto/factory/BookingDtoFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/factory/BookingDtoFactory.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.cslearning.record.domain.Booking;
 import uk.gov.cslearning.record.dto.BookingDto;
-import uk.gov.cslearning.record.dto.BookingStatus;
 
 import javax.ws.rs.core.UriBuilder;
 
@@ -33,7 +32,7 @@ public class BookingDtoFactory {
             bookingDto.setPaymentDetails(UriBuilder.fromUri(csrsBaseUrl).path(booking.getPaymentDetails()).build());
         }
 
-        bookingDto.setStatus(BookingStatus.forValue(booking.getStatus()));
+        bookingDto.setStatus(booking.getStatus());
 
         return bookingDto;
     }

--- a/src/main/java/uk/gov/cslearning/record/dto/factory/EventDtoFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/factory/EventDtoFactory.java
@@ -20,7 +20,7 @@ public class EventDtoFactory {
     public EventDto create(Event event) {
         EventDto eventDto = new EventDto();
         eventDto.setId(event.getId());
-        eventDto.setStatus(EventStatus.forValue(event.getStatus()));
+        eventDto.setStatus(event.getStatus());
         eventDto.setUri(UriBuilder.fromUri(learningCatalogueBaseUrl).path(event.getPath()).build());
         eventDto.setUid(event.getUid());
         eventDto.setCancellationReason(event.getCancellationReason());

--- a/src/main/java/uk/gov/cslearning/record/dto/factory/EventDtoFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/dto/factory/EventDtoFactory.java
@@ -23,6 +23,7 @@ public class EventDtoFactory {
         eventDto.setStatus(EventStatus.forValue(event.getStatus()));
         eventDto.setUri(UriBuilder.fromUri(learningCatalogueBaseUrl).path(event.getPath()).build());
         eventDto.setUid(event.getUid());
+        eventDto.setCancellationReason(event.getCancellationReason());
         return eventDto;
     }
 }

--- a/src/main/java/uk/gov/cslearning/record/service/DefaultEventService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/DefaultEventService.java
@@ -67,4 +67,9 @@ public class DefaultEventService implements EventService {
 
         return Optional.ofNullable(event);
     }
+
+    @Override
+    public EventDto create(EventDto eventDto){
+        return eventDtoFactory.create(eventRepository.save(eventFactory.create(eventDto)));
+    }
 }

--- a/src/main/java/uk/gov/cslearning/record/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/EventService.java
@@ -17,4 +17,7 @@ public interface EventService {
 
     @Transactional(readOnly = true)
     Optional<EventDto> findByUid(String eventUid);
+
+    @Transactional
+    EventDto create(EventDto eventDto);
 }

--- a/src/test/java/uk/gov/cslearning/record/api/EventControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/record/api/EventControllerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -138,4 +139,19 @@ public class EventControllerTest {
         verify(eventService).findByUid(eventUid);
     }
 
+    @Test
+    public void shouldCreateEvent() throws Exception {
+        EventDto eventDto = new EventDto();
+
+        when(eventService.create(eventDto)).thenReturn(eventDto);
+
+        mockMvc.perform(
+                post("/event").with(csrf())
+                        .content(objectMapper.writeValueAsString(eventDto))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        verify(eventService).create(eventDto);
+    }
 }

--- a/src/test/java/uk/gov/cslearning/record/domain/factory/BookingFactoryTest.java
+++ b/src/test/java/uk/gov/cslearning/record/domain/factory/BookingFactoryTest.java
@@ -59,7 +59,7 @@ public class BookingFactoryTest {
 
         Booking booking = bookingFactory.create(bookingDto);
 
-        assertThat(booking.getStatus(), equalTo(bookingDto.getStatus().getValue()));
+        assertThat(booking.getStatus(), equalTo(BookingStatus.CONFIRMED));
         assertThat(booking.getBookingTime(), equalTo(bookingDto.getBookingTime()));
         assertThat(booking.getPaymentDetails(), equalTo(bookingDto.getPaymentDetails().getPath()));
         assertThat(booking.getId(), equalTo(bookingDto.getId()));
@@ -90,7 +90,7 @@ public class BookingFactoryTest {
 
         Booking booking = bookingFactory.create(bookingDto);
 
-        assertThat(booking.getStatus(), equalTo(bookingDto.getStatus().getValue()));
+        assertThat(booking.getStatus(), equalTo(BookingStatus.CONFIRMED));
         assertThat(booking.getBookingTime(), equalTo(bookingDto.getBookingTime()));
         assertThat(booking.getPaymentDetails(), equalTo(bookingDto.getPaymentDetails().getPath()));
         assertThat(booking.getId(), equalTo(bookingDto.getId()));
@@ -118,7 +118,7 @@ public class BookingFactoryTest {
 
         Booking booking = bookingFactory.create(bookingDto);
 
-        assertThat(booking.getStatus(), equalTo(bookingDto.getStatus().getValue()));
+        assertThat(booking.getStatus(), equalTo(BookingStatus.CONFIRMED));
         assertThat(booking.getBookingTime(), equalTo(bookingDto.getBookingTime()));
         assertThat(booking.getId(), equalTo(bookingDto.getId()));
 

--- a/src/test/java/uk/gov/cslearning/record/domain/factory/EventFactoryTest.java
+++ b/src/test/java/uk/gov/cslearning/record/domain/factory/EventFactoryTest.java
@@ -38,7 +38,7 @@ public class EventFactoryTest {
 
         Event event = eventFactory.create(eventDto);
 
-        assertEquals(EventStatus.ACTIVE.getValue(), event.getStatus());
+        assertEquals(EventStatus.ACTIVE, event.getStatus());
         assertEquals(uid, event.getUid());
         assertEquals(uri.getPath(), event.getPath());
     }

--- a/src/test/java/uk/gov/cslearning/record/dto/factory/BookingDtoFactoryTest.java
+++ b/src/test/java/uk/gov/cslearning/record/dto/factory/BookingDtoFactoryTest.java
@@ -25,7 +25,7 @@ public class BookingDtoFactoryTest {
     @Test
     public void shouldReturnBookingDto() throws URISyntaxException {
         int bookingId = 99;
-        String status = "Confirmed";
+        BookingStatus status = BookingStatus.CONFIRMED;
         String paymentDetails = "/purchase-order/abcde12345";
         Instant bookingTime = LocalDateTime.now().toInstant(ZoneOffset.UTC);
 
@@ -59,13 +59,13 @@ public class BookingDtoFactoryTest {
         assertThat(bookingDto.getPaymentDetails(),
                 equalTo(new URI(String.join("", csrsBaseUri, paymentDetails))));
 
-        assertThat(bookingDto.getStatus(), equalTo(BookingStatus.forValue(status)));
+        assertThat(bookingDto.getStatus(), equalTo(status));
     }
 
     @Test
     public void shouldIgnoreMissingPaymentDetails() throws URISyntaxException {
         int bookingId = 99;
-        String status = "Confirmed";
+        BookingStatus status = BookingStatus.CONFIRMED;
         Instant bookingTime = LocalDateTime.now().toInstant(ZoneOffset.UTC);
 
         String learnerUuid = "learner-uuid";
@@ -95,6 +95,6 @@ public class BookingDtoFactoryTest {
         assertThat(bookingDto.getLearner(), equalTo(learnerUuid));
         assertThat(bookingDto.getLearnerEmail(), equalTo(learnerEmail));
 
-        assertThat(bookingDto.getStatus(), equalTo(BookingStatus.forValue(status)));
+        assertThat(bookingDto.getStatus(), equalTo(status));
     }
 }

--- a/src/test/java/uk/gov/cslearning/record/dto/factory/EventDtoFactoryTest.java
+++ b/src/test/java/uk/gov/cslearning/record/dto/factory/EventDtoFactoryTest.java
@@ -2,6 +2,7 @@ package uk.gov.cslearning.record.dto.factory;
 
 import org.junit.Test;
 import uk.gov.cslearning.record.domain.Event;
+import uk.gov.cslearning.record.dto.CancellationReason;
 import uk.gov.cslearning.record.dto.EventDto;
 import uk.gov.cslearning.record.dto.EventStatus;
 
@@ -24,11 +25,13 @@ public class EventDtoFactoryTest {
         event.setStatus(status);
         event.setPath(path);
         event.setUid(uid);
+        event.setCancellationReason(CancellationReason.UNAVAILABLE);
 
         EventDto eventDto = eventDtoFactory.create(event);
 
         assertEquals(EventStatus.forValue(status), eventDto.getStatus());
         assertEquals(URI.create(String.join("", catalogueUrl, path)), eventDto.getUri());
         assertEquals(uid, eventDto.getUid());
+        assertEquals(CancellationReason.UNAVAILABLE, eventDto.getCancellationReason());
     }
 }

--- a/src/test/java/uk/gov/cslearning/record/dto/factory/EventDtoFactoryTest.java
+++ b/src/test/java/uk/gov/cslearning/record/dto/factory/EventDtoFactoryTest.java
@@ -17,7 +17,7 @@ public class EventDtoFactoryTest {
 
     @Test
     public void shouldReturnEventDto() {
-        String status = "Active";
+        EventStatus status = EventStatus.ACTIVE;
         String path = "/path/to/event";
         String uid = "event-uid";
 
@@ -29,7 +29,7 @@ public class EventDtoFactoryTest {
 
         EventDto eventDto = eventDtoFactory.create(event);
 
-        assertEquals(EventStatus.forValue(status), eventDto.getStatus());
+        assertEquals(status, eventDto.getStatus());
         assertEquals(URI.create(String.join("", catalogueUrl, path)), eventDto.getUri());
         assertEquals(uid, eventDto.getUid());
         assertEquals(CancellationReason.UNAVAILABLE, eventDto.getCancellationReason());

--- a/src/test/java/uk/gov/cslearning/record/repository/BookingRepositoryTest.java
+++ b/src/test/java/uk/gov/cslearning/record/repository/BookingRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.cslearning.record.domain.Booking;
 import uk.gov.cslearning.record.domain.Event;
 import uk.gov.cslearning.record.domain.Learner;
+import uk.gov.cslearning.record.dto.BookingStatus;
 
 import javax.transaction.Transactional;
 import java.time.Instant;
@@ -38,7 +39,7 @@ public class BookingRepositoryTest {
         Booking booking = new Booking();
         booking.setEvent(event);
         booking.setLearner(learner);
-        booking.setStatus("CONFIRMED");
+        booking.setStatus(BookingStatus.CONFIRMED);
         booking.setPaymentDetails("payment/details");
         booking.setBookingTime(Instant.now());
 
@@ -65,7 +66,7 @@ public class BookingRepositoryTest {
         Booking booking = new Booking();
         booking.setEvent(event);
         booking.setLearner(learner);
-        booking.setStatus("CONFIRMED");
+        booking.setStatus(BookingStatus.CONFIRMED);
         booking.setPaymentDetails("payment/details");
         booking.setBookingTime(Instant.now());
 

--- a/src/test/java/uk/gov/cslearning/record/service/DefaultEventServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/DefaultEventServiceTest.java
@@ -128,4 +128,19 @@ public class DefaultEventServiceTest {
         verify(bookingService).unregister(booking2, "cancellation reason");
     }
 
+    @Test
+    public void shouldCreateNewEvent(){
+        EventDto eventDto = new EventDto();
+        Event event = new Event();
+
+        when(eventFactory.create(eventDto)).thenReturn(event);
+        when(eventRepository.save(event)).thenReturn(event);
+        when(eventDtoFactory.create(event)).thenReturn(eventDto);
+
+        assertEquals(eventService.create(eventDto), eventDto);
+
+        verify(eventFactory).create(eventDto);
+        verify(eventRepository).save(event);
+        verify(eventDtoFactory).create(event);
+    }
 }


### PR DESCRIPTION
This allows events to be created directly at the same time as they are created in the learning-catalogue, this is necessary because events now have a status which needs to be stored and changed learner record even when the vent doesn't have any bookings.

- Added create endpoint to EventController.java for directly creating events.
- Added set cancellation reason in EventDtoFactory.java
- Added create function to EventService.java
