### PR TITLE
Adding db migration to update booking_reference to avoid having null values

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/service/catalogue/LearningCatalogueService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/catalogue/LearningCatalogueService.java
@@ -55,9 +55,22 @@ public class LearningCatalogueService {
         return emptyList();
     }
 
-    @Cacheable("courseId")
     public Course getCourse(String courseId) {
         try {
+            LOGGER.debug("This function doesn't cache a course");
+            RequestEntity requestEntity = requestEntityFactory.createGetRequest(String.format(courseUrlFormat, courseId));
+            ResponseEntity<Course> responseEntity = restTemplate.exchange(requestEntity, Course.class);
+            return responseEntity.getBody();
+        } catch (RequestEntityException | RestClientException e) {
+            LOGGER.error("Could not get course from learning catalogue: ", e.getLocalizedMessage());
+            return null;
+        }
+    }
+
+    @Cacheable("courseId")
+    public Course getCachedCourse(String courseId) {
+        try {
+            LOGGER.debug("This function caches a course which used for statements");
             RequestEntity requestEntity = requestEntityFactory.createGetRequest(String.format(courseUrlFormat, courseId));
             ResponseEntity<Course> responseEntity = restTemplate.exchange(requestEntity, Course.class);
             return responseEntity.getBody();

--- a/src/main/java/uk/gov/cslearning/record/service/xapi/StatementStream.java
+++ b/src/main/java/uk/gov/cslearning/record/service/xapi/StatementStream.java
@@ -78,7 +78,7 @@ public class StatementStream {
                     }
                     CourseRecord courseRecord = records.get(courseId);
                     uk.gov.cslearning.record.service.catalogue.Course catalogueCourse
-                            = learningCatalogueService.getCourse(courseId);
+                            = learningCatalogueService.getCachedCourse(courseId);
 
                     if (catalogueCourse == null) {
                         LOGGER.info("Ignoring statement with no catalogue course, courseId: {}", courseId);

--- a/src/main/resources/db/migration/h2/V1.4.2__updating_booking_reference_null_values.sql
+++ b/src/main/resources/db/migration/h2/V1.4.2__updating_booking_reference_null_values.sql
@@ -1,0 +1,15 @@
+/*
+Updating the booking reference to be a code of 5 characters excluding 0,1,O,I where the booking reference is null.
+Inside the concat function, we create the code letter by letter. This is done by getting a random character from the substring specified
+with min index being 1 and max being 31. The second parameter (1) in the SUBSTRING function specifies the number of character that we want.
+Then we concat all of the separate characters into one code and update booking_reference.
+*/
+UPDATE booking
+SET booking_reference = (Select CONCAT(
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1)
+))
+WHERE booking_reference IS NULL;

--- a/src/main/resources/db/migration/mysql/V1.4.2__updating_booking_reference_null_values.sql
+++ b/src/main/resources/db/migration/mysql/V1.4.2__updating_booking_reference_null_values.sql
@@ -1,0 +1,15 @@
+/*
+Updating the booking reference to be a code of 5 characters excluding 0,1,O,I where the booking reference is null.
+Inside the concat function, we create the code letter by letter. This is done by getting a random character from the substring specified
+with min index being 1 and max being 31. The second parameter (1) in the SUBSTRING function specifies the number of character that we want.
+Then we concat all of the separate characters into one code and update booking_reference.
+*/
+UPDATE booking
+SET booking_reference = (Select CONCAT(
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1),
+	SUBSTRING('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', FLOOR(RAND()*31+1), 1)
+))
+WHERE booking_reference IS NULL;

--- a/src/test/java/uk/gov/cslearning/record/api/ReportControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/record/api/ReportControllerTest.java
@@ -65,6 +65,7 @@ public class ReportControllerTest {
         booking.setPaymentDetails(paymentDetails);
         booking.setEvent(event);
         booking.setLearner(learnerUid);
+        booking.setBookingReference("AB45C");
 
         when(bookingService.findAllForPeriod(LocalDate.parse("2018-01-01"), LocalDate.parse("2018-01-31")))
                 .thenReturn(Collections.singletonList(booking));

--- a/src/test/java/uk/gov/cslearning/record/service/UserRecordServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/UserRecordServiceTest.java
@@ -85,7 +85,7 @@ public class UserRecordServiceTest {
 
         Statement statement = createStatement(activityId, uk.gov.cslearning.record.service.xapi.Verb.ARCHIVED);
 
-        when(learningCatalogueService.getCourse(eq(courseId))).thenReturn(createCourse(courseId));
+        when(learningCatalogueService.getCachedCourse(eq(courseId))).thenReturn(createCourse(courseId));
         when(xApiService.getStatements(eq(userId), eq(null), any())).thenReturn(ImmutableSet.of(statement));
         when(registryService.getCivilServantByUid(userId)).thenReturn(Optional.of(new CivilServant()));
         when(courseRecordRepository.findByUserId(userId)).thenReturn(savedCourseRecords);

--- a/src/test/java/uk/gov/cslearning/record/service/catalogue/LearningCatalogueServiceCacheTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/catalogue/LearningCatalogueServiceCacheTest.java
@@ -41,9 +41,9 @@ public class LearningCatalogueServiceCacheTest {
         when(restTemplate.exchange(eq(requestEntity), eq(Course.class))).thenReturn(responseEntity);
         when(responseEntity.getBody()).thenReturn(course);
 
-        learningCatalogueService.getCourse(courseId);
-        learningCatalogueService.getCourse(courseId);
-        Course result = learningCatalogueService.getCourse(courseId);
+        learningCatalogueService.getCachedCourse(courseId);
+        learningCatalogueService.getCachedCourse(courseId);
+        Course result = learningCatalogueService.getCachedCourse(courseId);
 
         assertEquals(course, result);
 


### PR DESCRIPTION
This is done to fix the problem where the learner tries to delete a booking for a course which were created before adding references to booking code.