### PR TITLE
Healthcheck endpoint

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/api/HealthController.java
+++ b/src/main/java/uk/gov/cslearning/record/api/HealthController.java
@@ -1,0 +1,14 @@
+package uk.gov.cslearning.record.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/health")
+public class HealthController {
+    @GetMapping()
+    public String getHealthCheck(){
+        return "ONLINE";
+    }
+}

--- a/src/main/java/uk/gov/cslearning/record/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/cslearning/record/config/SecurityConfig.java
@@ -8,8 +8,10 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
@@ -43,7 +45,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
 
         http.csrf().disable().authorizeRequests()
+                .antMatchers(HttpMethod.GET, "/health").permitAll()
                 .anyRequest().authenticated();
+    }
+
+    @Override
+    public void configure(WebSecurity webSecurity) throws Exception{
+        webSecurity.ignoring().antMatchers(HttpMethod.GET, "/health");
     }
 
     @Bean


### PR DESCRIPTION
This change:

* Creates a new endpoint `/health` to be used as a health check for the service.
* Updates the security configuration so that the `/health` endpoint is available without authentication