### PR TITLE
LC-2762: Fix Flyway scripts

### DIFF
--- a/src/main/resources/db/migration/h2/V1.5.0__add_shedlock_table_and_is_required_column.sql
+++ b/src/main/resources/db/migration/h2/V1.5.0__add_shedlock_table_and_is_required_column.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `shedlock` (
   `name` VARCHAR(64) NOT NULL,
   `lock_until` TIMESTAMP NOT NULL,
-  `locked_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `locked_at` TIMESTAMP NOT NULL,
   `locked_by` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/main/resources/db/migration/h2/V1.5.0__add_shedlock_table_and_is_required_column.sql
+++ b/src/main/resources/db/migration/h2/V1.5.0__add_shedlock_table_and_is_required_column.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `shedlock` (
   `name` VARCHAR(64) NOT NULL,
   `lock_until` TIMESTAMP NOT NULL,
-  `locked_at` TIMESTAMP NOT NULL,
+  `locked_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `locked_by` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/main/resources/db/migration/mysql/V1.5.0__add_shedlock_table_and_is_required_column.sql
+++ b/src/main/resources/db/migration/mysql/V1.5.0__add_shedlock_table_and_is_required_column.sql
@@ -1,20 +1,20 @@
 CREATE TABLE `shedlock` (
-  `name` VARCHAR(64) NOT NULL,
-  `lock_until` TIMESTAMP NOT NULL,
-  `locked_at` TIMESTAMP NOT NULL,
-  `locked_by` VARCHAR(255) NOT NULL,
-  PRIMARY KEY (`name`)
+    `name` VARCHAR(64) NOT NULL,
+    `lock_until` TIMESTAMP NOT NULL,
+    `locked_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `locked_by` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE course_record ADD COLUMN is_required BOOLEAN DEFAULT FALSE;
 
 CREATE TABLE `course_notification_job_history` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `name` VARCHAR(64) NOT NULL,
-  `started_at` TIMESTAMP NOT NULL,
-  `completed_at` TIMESTAMP,
-  `data_acquisition` TIMESTAMP,
-  PRIMARY KEY (`id`)
+    `id` bigint NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(64) NOT NULL,
+    `started_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `completed_at` TIMESTAMP NULL,
+    `data_acquisition` TIMESTAMP NULL,
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO course_notification_job_history(name, started_at, completed_at, data_acquisition)


### PR DESCRIPTION
This change fixes the Flyway scripts so they can run against a blank database.

In `V1.5.0__add_shedlock_table_and_is_required_column.sql` these are the schema changes:

* The `locked_at` column in the `shedlock` table now has a default value of `CURRENT_TIMESTAMP`. It is a requirement for `TIMESTAMP` columns to have a default value.
* The `started_at` column in the `course_notification_job_history` table also has a default value, for the same reason
* The `completed_at` and `data_acquisition` columns in the `course_notification_job_history` table are now accepting `NULL`. `TIMESTAMP` columns are `NOT NULL` by default, so we need to specify if we need them to be accepting `NULL` values.