### PR TITLE
LC-3482 use full hierarchy for learning job

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/client/HttpClient.java
+++ b/src/main/java/uk/gov/cslearning/record/client/HttpClient.java
@@ -8,7 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -35,29 +34,11 @@ public class HttpClient implements IHttpClient {
         }
     }
 
-    public <T, R> Map<String, T> executeMapRequest(RequestEntity<R> request, ParameterizedTypeReference<Map<String, T>> ptr) {
-        try {
-            log.debug("Sending request: {}", request);
-            ResponseEntity<Map<String, T>> response = restTemplate.exchange(request, ptr);
-            log.debug("Request response: {}", response);
-            return response.getBody();
-        } catch (RestClientResponseException e) {
-            String msg = String.format("Error sending '%s' request to endpoint", request.getMethod());
-            if (request.getBody() != null) {
-                msg = String.format("%s Body was: %s.", msg, request.getBody().toString());
-            }
-            msg = String.format("%s Error was: %s", msg, e.getMessage());
-            log.error(msg);
-            throw e;
-        }
-    }
-
     @Override
-    public <T, R> List<T> executeListRequest(RequestEntity<R> request, ParameterizedTypeReference<List<T>> parameterizedTypeReference) {
+    public <T, R> T executeTypeRequest(RequestEntity<R> request, ParameterizedTypeReference<T> parameterizedTypeReference) {
         try {
             log.debug("Sending request: {}", request);
-            ResponseEntity<List<T>> response = restTemplate.exchange(request, parameterizedTypeReference);
-
+            ResponseEntity<T> response = restTemplate.exchange(request, parameterizedTypeReference);
             log.debug("Request response: {}", response);
             return response.getBody();
         } catch (RestClientResponseException e) {
@@ -70,4 +51,9 @@ public class HttpClient implements IHttpClient {
             throw e;
         }
     }
+
+    public <T, R> Map<String, T> executeMapRequest(RequestEntity<R> request, ParameterizedTypeReference<Map<String, T>> ptr) {
+        return executeTypeRequest(request, ptr);
+    }
+
 }

--- a/src/main/java/uk/gov/cslearning/record/client/IHttpClient.java
+++ b/src/main/java/uk/gov/cslearning/record/client/IHttpClient.java
@@ -3,13 +3,12 @@ package uk.gov.cslearning.record.client;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 
-import java.util.List;
 import java.util.Map;
 
 public interface IHttpClient {
     <T, R> T executeRequest(RequestEntity<R> request, Class<T> responseClass);
 
-    <T, R> Map<String, T> executeMapRequest(RequestEntity<R> request, ParameterizedTypeReference<Map<String, T>> parameterizedTypeReference);
+    <T, R> T executeTypeRequest(RequestEntity<R> request, ParameterizedTypeReference<T> parameterizedTypeReference);
 
-    <T, R> List<T> executeListRequest(RequestEntity<R> request, ParameterizedTypeReference<List<T>> parameterizedTypeReference);
+    <T, R> Map<String, T> executeMapRequest(RequestEntity<R> request, ParameterizedTypeReference<Map<String, T>> parameterizedTypeReference);
 }

--- a/src/main/java/uk/gov/cslearning/record/client/civilServantRegistry/CivilServantRegistryClient.java
+++ b/src/main/java/uk/gov/cslearning/record/client/civilServantRegistry/CivilServantRegistryClient.java
@@ -8,9 +8,16 @@ import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
 import uk.gov.cslearning.record.client.IHttpClient;
 import uk.gov.cslearning.record.csrs.domain.CivilServant;
+import uk.gov.cslearning.record.csrs.domain.GetPageResponse;
+import uk.gov.cslearning.record.csrs.domain.OrganisationalUnit;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
 
 @Slf4j
 @Component
@@ -19,13 +26,22 @@ public class CivilServantRegistryClient implements ICivilServantRegistryClient {
     private final IHttpClient httpClient;
     private final String getResourceByUidUrl;
     private final String getResourceByOrgCodeUrl;
+    private final String organisationalUnitsUrl;
+    private final Integer getOrganisationsMaxPageSize;
+    private final Integer getCSUidsMaxPageSize;
 
     public CivilServantRegistryClient(@Qualifier("civilServantRegistryHttpClient") IHttpClient httpClient,
                                       @Value("${registry-service.getResourceByUidUrl}") String getResourceByUidUrl,
-                                      @Value("${registry-service.getResourceByOrgCodeUrl}") String getResourceByOrgCodeUrl) {
+                                      @Value("${registry-service.getResourceByOrgCodeUrl}") String getResourceByOrgCodeUrl,
+                                      @Value("${registry-service.organisationalUnitsUrl}") String organisationalUnitsUrl,
+                                      @Value("${registry-service.getOrganisationsMaxPageSize}") Integer getOrganisationsMaxPageSize,
+                                      @Value("${registry-service.getCSUidsMaxPageSize}") Integer getCSUidsMaxPageSize) {
         this.httpClient = httpClient;
         this.getResourceByUidUrl = getResourceByUidUrl;
         this.getResourceByOrgCodeUrl = getResourceByOrgCodeUrl;
+        this.organisationalUnitsUrl = organisationalUnitsUrl;
+        this.getOrganisationsMaxPageSize = getOrganisationsMaxPageSize;
+        this.getCSUidsMaxPageSize = getCSUidsMaxPageSize;
     }
 
     @Override
@@ -38,14 +54,51 @@ public class CivilServantRegistryClient implements ICivilServantRegistryClient {
         return Optional.ofNullable(httpClient.executeRequest(request, CivilServant.class));
     }
 
-    @Override
-    public List<CivilServant> getCivilServantsByOrgCode(String code) {
-        log.debug("Getting profile details for civil servants with organisation code {}", code);
-        String url = String.format(getResourceByOrgCodeUrl, code);
-        RequestEntity<Void> request = RequestEntity
-                .get(url)
-                .build();
-        return httpClient.executeListRequest(request, new ParameterizedTypeReference<>() {
+    private GetPageResponse<OrganisationalUnit> getOrganisations(Integer size, Integer page) {
+        String url = organisationalUnitsUrl + String.format("?size=%s&page=%s", size, page);
+        RequestEntity<Void> request = RequestEntity.get(url).build();
+        return httpClient.executeTypeRequest(request, new ParameterizedTypeReference<>() {
         });
+    }
+
+    @Override
+    public List<OrganisationalUnit> getAllOrganisationalUnits() {
+        List<OrganisationalUnit> organisationalUnits = new ArrayList<>();
+        GetPageResponse<OrganisationalUnit> initialResponse = getOrganisations(1, 0);
+        if (initialResponse.getTotalElements() >= 1) {
+            List<CompletableFuture<List<OrganisationalUnit>>> futures =
+                    IntStream.range(0, (int) Math.ceil((double) initialResponse.getTotalElements() / getOrganisationsMaxPageSize))
+                            .boxed()
+                            .map(i -> CompletableFuture.supplyAsync(() -> getOrganisations(getOrganisationsMaxPageSize, i).getContent())).toList();
+
+            organisationalUnits = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenApply(i -> futures.stream().flatMap(listCompletableFuture -> listCompletableFuture.join().stream()).collect(toList())).join();
+
+        }
+        return organisationalUnits;
+    }
+
+    private GetPageResponse<String> getCivilServantUidsByOrgCode(String orgCode, Integer size, Integer page) {
+        String url = String.format("%s/%s?size=%s&page=%s", getResourceByOrgCodeUrl, orgCode, size, page);
+        RequestEntity<Void> request = RequestEntity.get(url).build();
+        return httpClient.executeTypeRequest(request, new ParameterizedTypeReference<>() {
+        });
+    }
+
+    @Override
+    public List<String> getCivilServantUidsByOrgCode(String code) {
+        List<String> uids = new ArrayList<>();
+        GetPageResponse<String> initialResponse = getCivilServantUidsByOrgCode(code, 1, 0);
+        if (initialResponse.getTotalElements() >= 1) {
+            List<CompletableFuture<List<String>>> futures =
+                    IntStream.range(0, (int) Math.ceil((double) initialResponse.getTotalElements() / getCSUidsMaxPageSize))
+                            .boxed()
+                            .map(i -> CompletableFuture.supplyAsync(() -> getCivilServantUidsByOrgCode(code, getCSUidsMaxPageSize, i).getContent())).toList();
+
+            uids = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenApply(i -> futures.stream().flatMap(listCompletableFuture -> listCompletableFuture.join().stream()).collect(toList())).join();
+
+        }
+        return uids;
     }
 }

--- a/src/main/java/uk/gov/cslearning/record/client/civilServantRegistry/ICivilServantRegistryClient.java
+++ b/src/main/java/uk/gov/cslearning/record/client/civilServantRegistry/ICivilServantRegistryClient.java
@@ -1,6 +1,7 @@
 package uk.gov.cslearning.record.client.civilServantRegistry;
 
 import uk.gov.cslearning.record.csrs.domain.CivilServant;
+import uk.gov.cslearning.record.csrs.domain.OrganisationalUnit;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +10,7 @@ public interface ICivilServantRegistryClient {
 
     Optional<CivilServant> getCivilServantResourceByUid(String uid);
 
-    List<CivilServant> getCivilServantsByOrgCode(String code);
-
+    List<OrganisationalUnit> getAllOrganisationalUnits();
+    
+    List<String> getCivilServantUidsByOrgCode(String code);
 }

--- a/src/main/java/uk/gov/cslearning/record/csrs/domain/GetPageResponse.java
+++ b/src/main/java/uk/gov/cslearning/record/csrs/domain/GetPageResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.cslearning.record.csrs.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetPageResponse<T> {
+    private List<T> content;
+    private Integer page;
+    private Integer totalPages;
+    private Integer totalElements;
+    private Integer size;
+}

--- a/src/main/java/uk/gov/cslearning/record/csrs/domain/OrganisationalUnit.java
+++ b/src/main/java/uk/gov/cslearning/record/csrs/domain/OrganisationalUnit.java
@@ -9,6 +9,8 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 public class OrganisationalUnit {
+    private Integer id;
+    private Integer parentId;
     private String code;
     private String name;
     private List<String> paymentMethods = new ArrayList<>();

--- a/src/main/java/uk/gov/cslearning/record/csrs/service/RegistryService.java
+++ b/src/main/java/uk/gov/cslearning/record/csrs/service/RegistryService.java
@@ -4,9 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.cslearning.record.client.civilServantRegistry.ICivilServantRegistryClient;
 import uk.gov.cslearning.record.csrs.domain.CivilServant;
+import uk.gov.cslearning.record.csrs.domain.OrganisationalUnit;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -22,8 +26,28 @@ public class RegistryService {
         return civilServantRegistryClient.getCivilServantResourceByUid(uid);
     }
 
-    public List<CivilServant> getCivilServantsByOrgCode(String code) {
-        return civilServantRegistryClient.getCivilServantsByOrgCode(code);
+    public List<String> getCivilServantsByOrgCode(String code) {
+        return civilServantRegistryClient.getCivilServantUidsByOrgCode(code);
+    }
+
+    /**
+     * @return a list of org hierarchies, starting with the lowest tier and cascading up
+     */
+    public List<List<String>> getOrganisationCodeHierarchy() {
+        List<List<String>> fullHierarchy = new ArrayList<>();
+        Map<Integer, OrganisationalUnit> orgMap = civilServantRegistryClient.getAllOrganisationalUnits()
+                .stream().collect(Collectors.toMap(OrganisationalUnit::getId, o -> o));
+        for (OrganisationalUnit org : orgMap.values()) {
+            List<String> hierarchy = new ArrayList<>(List.of(org.getCode()));
+            Integer parentId = org.getParentId();
+            while (parentId != null) {
+                OrganisationalUnit parent = orgMap.get(parentId);
+                hierarchy.add(parent.getCode());
+                parentId = parent.getParentId();
+            }
+            fullHierarchy.add(hierarchy);
+        }
+        return fullHierarchy;
     }
 
 }

--- a/src/main/java/uk/gov/cslearning/record/service/catalogue/CourseDataFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/service/catalogue/CourseDataFactory.java
@@ -8,6 +8,7 @@ import uk.gov.cslearning.record.util.IUtilService;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -38,13 +39,20 @@ public class CourseDataFactory {
         });
     }
 
-    public RequiredCourse transformCourse(Course course) {
+    public RequiredCourse transformCourse(Course course, List<List<String>> departmentHierarchies) {
         Map<String, LearningPeriod> learningPeriodMap = new HashMap<>();
         course.getAudiences().forEach(a -> {
             LearningPeriod learningPeriod = getLearningPeriod(a);
-            a.getDepartments().forEach(dep -> {
-                learningPeriodMap.putIfAbsent(dep, learningPeriod);
-            });
+            a.getDepartments().forEach(dep -> learningPeriodMap.putIfAbsent(dep, learningPeriod));
+        });
+        departmentHierarchies.forEach(hierarchy -> {
+            for (String org : hierarchy) {
+                LearningPeriod lp = learningPeriodMap.get(org);
+                if (lp != null) {
+                    learningPeriodMap.put(hierarchy.get(0), lp);
+                    break;
+                }
+            }
         });
         return new RequiredCourse(course.getId(), course.getTitle(), course.getModules(), course.getAudiences(),
                 learningPeriodMap);

--- a/src/main/java/uk/gov/cslearning/record/service/catalogue/LearningCatalogueService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/catalogue/LearningCatalogueService.java
@@ -3,7 +3,9 @@ package uk.gov.cslearning.record.service.catalogue;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.cslearning.record.client.learningCatalogue.ILearningCatalogueClient;
+import uk.gov.cslearning.record.csrs.service.RegistryService;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,19 +17,40 @@ public class LearningCatalogueService {
     private final ILearningCatalogueClient learningCatalogueClient;
     private final CourseDataFactory courseDataFactory;
 
+    private final RegistryService registryService;
+
     public LearningCatalogueService(ILearningCatalogueClient learningCatalogueClient,
-                                    CourseDataFactory courseDataFactory) {
+                                    CourseDataFactory courseDataFactory, RegistryService registryService) {
         this.learningCatalogueClient = learningCatalogueClient;
         this.courseDataFactory = courseDataFactory;
+        this.registryService = registryService;
     }
 
     public Map<String, List<RequiredCourse>> getRequiredCoursesByDueDaysGroupedByOrg(List<Long> dueDays) {
         Map<String, List<RequiredCourse>> response = new HashMap<>();
+        Map<String, List<RequiredCourse>> orgsToRequiredLearning = new HashMap<>();
+        List<List<String>> hierarchies = registryService.getOrganisationCodeHierarchy();
         learningCatalogueClient.getRequiredCoursesByDueDaysGroupedByOrg(dueDays.stream().map(Object::toString).toList())
                 .forEach((department, courses) -> {
-                    List<RequiredCourse> transformedCourses = courses.stream().map(courseDataFactory::transformCourse).toList();
-                    response.putIfAbsent(department, transformedCourses);
+                    List<RequiredCourse> transformedCourses = courses.stream().map(c -> courseDataFactory.transformCourse(c, hierarchies)).toList();
+                    orgsToRequiredLearning.putIfAbsent(department, transformedCourses);
                 });
+        for (List<String> hierarchy : hierarchies) {
+            for (String org : hierarchy) {
+                List<RequiredCourse> requiredLearningForOrg = orgsToRequiredLearning.get(org);
+                if (requiredLearningForOrg != null) {
+                    List<RequiredCourse> coursesToAdd = new ArrayList<>();
+                    List<String> coursesAdded = new ArrayList<>();
+                    for (RequiredCourse requiredCourse : requiredLearningForOrg) {
+                        if (!coursesAdded.contains(requiredCourse.getId())) {
+                            coursesToAdd.add(requiredCourse);
+                            coursesAdded.add(requiredCourse.getId());
+                        }
+                    }
+                    response.put(hierarchy.get(0), coursesToAdd);
+                }
+            }
+        }
         return response;
     }
 

--- a/src/main/java/uk/gov/cslearning/record/service/scheduler/LearningJob.java
+++ b/src/main/java/uk/gov/cslearning/record/service/scheduler/LearningJob.java
@@ -125,7 +125,7 @@ public class LearningJob {
     }
 
     private List<CourseRecords> groupCourseRecordsByUserId(String orgCode, List<String> courseIds) {
-        List<String> uids = registryService.getCivilServantsByOrgCode(orgCode).stream().map(cs -> cs.getIdentity().getUid()).toList();
+        List<String> uids = registryService.getCivilServantsByOrgCode(orgCode);
         log.info("Fetched {} uids for department {}", uids.size(), orgCode);
         return courseRecordService.getCourseRecords(uids, courseIds);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,7 +81,10 @@ identity:
 registry-service:
   serviceUrl: ${REGISTRY_SERVICE_URL:http://localhost:9002}
   getResourceByUidUrl: "/civilServants/resource/%s"
-  getResourceByOrgCodeUrl: "/civilServants/organisation/%s"
+  getResourceByOrgCodeUrl: "/civilServants/organisation"
+  organisationalUnitsUrl: "/v2/organisationalUnits"
+  getOrganisationsMaxPageSize: 200
+  getCSUidsMaxPageSize: 5000
 
 catalogue:
   serviceUrl: ${LEARNING_CATALOGUE_SERVICE_URL:http://localhost:9001}

--- a/src/test/java/uk/gov/cslearning/record/service/scheduler/learningJob/LearningJobTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/scheduler/learningJob/LearningJobTest.java
@@ -104,50 +104,40 @@ public class LearningJobTest extends IntegrationTestBase {
         String requiredLearningResponse = objectMapper.writeValueAsString(generateRequiredCourses());
         stubService.getLearningCatalogueStubService().getRequiredCoursesByDueDaysGroupedByOrg("1,5", requiredLearningResponse);
 
-        Map.of("CO", """
-                                [
-                                  {
-                                    "identity": {
-                                      "uid": "coCivilServant1"
-                                    }
-                                  },
-                                  {
-                                    "identity": {
-                                      "uid": "coCivilServant2"
-                                    }
-                                  }
-                                ]
-                                """,
-                        "DWP", """
-                                [
-                                  {
-                                    "identity": {
-                                      "uid": "dwpCivilServant1"
-                                    }
-                                  },
-                                  {
-                                    "identity": {
-                                      "uid": "dwpCivilServant2"
-                                    }
-                                  }
-                                ]
-                                                                
-                                """,
-                        "HMRC", """
-                                [
-                                  {
-                                    "identity": {
-                                      "uid": "hmrcCivilServant1"
-                                    }
-                                  },
-                                  {
-                                    "identity": {
-                                      "uid": "hmrcCivilServant2"
-                                    }
-                                  }
-                                ]
-                                """)
-                .forEach((depCode, json) -> stubService.getCsrsStubService().getCivilServantsForDepartment(depCode, json));
+        stubService.getCsrsStubService().getDepartments(0, 1, """
+                {"content": [{"code": "HMRC", "id": 1}], "totalElements": 4}
+                """);
+        stubService.getCsrsStubService().getDepartments(0, 200, """
+                {"content": [
+                    {"code": "HMRC","id": 1},
+                    {"code": "DWP","id": 2},
+                    {"code": "CO","id": 3},
+                    {"code": "COD", "id": 4, "parentId": 3}
+                ], "totalElements": 4}
+                """);
+
+        stubService.getCsrsStubService().getCivilServantsForDepartment("CO", 0, 1, """
+                {"content": [], "totalElements": 0}
+                """);
+
+        stubService.getCsrsStubService().getCivilServantsForDepartment("COD", 0, 1, """
+                {"content": ["coCivilServant1"], "totalElements": 2}
+                """);
+        stubService.getCsrsStubService().getCivilServantsForDepartment("COD", 0, 5000, """
+                {"content": ["coCivilServant1", "coCivilServant2"], "totalElements": 2}
+                """);
+        stubService.getCsrsStubService().getCivilServantsForDepartment("DWP", 0, 1, """
+                {"content": ["dwpCivilServant1"], "totalElements": 2}
+                """);
+        stubService.getCsrsStubService().getCivilServantsForDepartment("DWP", 0, 5000, """
+                {"content": ["dwpCivilServant1", "dwpCivilServant2"], "totalElements": 2}
+                """);
+        stubService.getCsrsStubService().getCivilServantsForDepartment("HMRC", 0, 1, """
+                {"content": ["hmrcCivilServant1"], "totalElements": 2}
+                """);
+        stubService.getCsrsStubService().getCivilServantsForDepartment("HMRC", 0, 5000, """
+                {"content": ["hmrcCivilServant1", "hmrcCivilServant2"], "totalElements": 2}
+                """);
     }
 
     private CourseRecord createCourseRecordForUser(String uid, String courseId, Map<String, LocalDateTime> moduleRecords) {

--- a/src/test/java/uk/gov/cslearning/record/util/stub/CSRSStubService.java
+++ b/src/test/java/uk/gov/cslearning/record/util/stub/CSRSStubService.java
@@ -3,6 +3,8 @@ package uk.gov.cslearning.record.util.stub;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 @Service
@@ -18,9 +20,10 @@ public class CSRSStubService {
         );
     }
 
-    public void getCivilServantsForDepartment(String departmentCode, String response) {
+    public void getCivilServantsForDepartment(String departmentCode, Integer page, Integer size, String response) {
         stubFor(
                 WireMock.get(urlPathEqualTo("/csrs/civilServants/organisation/" + departmentCode))
+                        .withQueryParams(Map.of("page", equalTo(page.toString()), "size", equalTo(size.toString())))
                         .withHeader("Authorization", equalTo("Bearer token"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
@@ -28,4 +31,14 @@ public class CSRSStubService {
         );
     }
 
+    public void getDepartments(Integer page, Integer size, String response) {
+        stubFor(
+                WireMock.get(urlPathEqualTo("/csrs/v2/organisationalUnits"))
+                        .withQueryParams(Map.of("page", equalTo(page.toString()), "size", equalTo(size.toString())))
+                        .withHeader("Authorization", equalTo("Bearer token"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(response))
+        );
+    }
 }


### PR DESCRIPTION
- Fetch the department hiearchy when calculating required learning so that T2/T3 organisations are included
- Fetch civil servant UIDs in a paginated way to reduce load on CSRS