### PR TITLE
LC 3620 learner record pagination

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/api/record/LeanerRecordController.java
+++ b/src/main/java/uk/gov/cslearning/record/api/record/LeanerRecordController.java
@@ -30,7 +30,7 @@ public class LeanerRecordController {
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
-    public Page<LearnerRecordDto> getRecords(@PageableDefault(sort = {"createdTimestamp"}, direction = Sort.Direction.ASC) Pageable pageableParams,
+    public Page<LearnerRecordDto> getRecords(@PageableDefault(sort = {"createdTimestamp", "id"}, direction = Sort.Direction.ASC) Pageable pageableParams,
                                              LearnerRecordQuery learnerRecordQuery) {
         return learnerRecordService.getRecords(pageableParams, learnerRecordQuery);
     }

--- a/src/main/java/uk/gov/cslearning/record/api/record/LearnerRecordEventController.java
+++ b/src/main/java/uk/gov/cslearning/record/api/record/LearnerRecordEventController.java
@@ -29,7 +29,7 @@ public class LearnerRecordEventController {
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
-    public Page<LearnerRecordEventDto> getEvents(@PageableDefault(sort = {"eventTimestamp"}, direction = Sort.Direction.ASC) Pageable pageableParams,
+    public Page<LearnerRecordEventDto> getEvents(@PageableDefault(sort = {"eventTimestamp", "id"}, direction = Sort.Direction.ASC) Pageable pageableParams,
                                                  LearnerRecordEventQuery query) {
         return learnerRecordEventService.getRecords(pageableParams, query);
     }

--- a/src/main/java/uk/gov/cslearning/record/service/LearnerRecordService.java
+++ b/src/main/java/uk/gov/cslearning/record/service/LearnerRecordService.java
@@ -53,7 +53,7 @@ public class LearnerRecordService {
         Page<LearnerRecord> results = learnerRecordRepository.find(learnerRecordQuery.getLearnerIds(), learnerRecordQuery.getResourceIds(),
                 learnerRecordQuery.getLearnerRecordTypes(), pageableParams);
         List<LearnerRecordDto> dtos = results.get().map(this.learnerRecordFactory::createLearnerRecordDto).toList();
-        return new PageImpl<>(dtos, pageableParams, dtos.size());
+        return new PageImpl<>(dtos, pageableParams, results.getTotalElements());
     }
 
     public void createRecordIfNotExists(String resourceId, String learnerId, String type, LocalDateTime createdTimestamp) {

--- a/src/main/java/uk/gov/cslearning/record/service/factory/LearnerRecordEventFactory.java
+++ b/src/main/java/uk/gov/cslearning/record/service/factory/LearnerRecordEventFactory.java
@@ -44,7 +44,7 @@ public class LearnerRecordEventFactory {
 
     public Page<LearnerRecordEventDto> createDtos(Pageable pageable, Page<LearnerRecordEvent> events) {
         List<LearnerRecordEventDto> eventDtos = events.map(this::createDto).stream().toList();
-        return new PageImpl<>(eventDtos, pageable, eventDtos.size());
+        return new PageImpl<>(eventDtos, pageable, events.getTotalElements());
     }
 
     public LearnerRecordEventDto createDto(LearnerRecordEvent event) {

--- a/src/test/java/uk/gov/cslearning/record/integration/record/CourseRecordTest.java
+++ b/src/test/java/uk/gov/cslearning/record/integration/record/CourseRecordTest.java
@@ -1,6 +1,7 @@
 package uk.gov.cslearning.record.integration.record;
 
 
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import uk.gov.cslearning.record.IntegrationTestBase;
 
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Transactional
 public class CourseRecordTest extends IntegrationTestBase {
 
     @Test

--- a/src/test/java/uk/gov/cslearning/record/integration/record/LearnerRecordTest.java
+++ b/src/test/java/uk/gov/cslearning/record/integration/record/LearnerRecordTest.java
@@ -158,6 +158,37 @@ public class LearnerRecordTest extends IntegrationTestBase {
     }
 
     @Test
+    public void testGetLearnerRecordsPagination() throws Exception {
+        mockMvc.perform(get("/learner_records")
+                        .with(csrf())
+                        .param("resourceId", "course1")
+                        .param("size", "1")
+                        .param("page", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("totalElements").value(7))
+                .andExpect(jsonPath("content[0].recordType.type").value("COURSE"))
+                .andExpect(jsonPath("content[0].uid").isNotEmpty());
+        mockMvc.perform(get("/learner_records")
+                        .with(csrf())
+                        .param("resourceId", "course1")
+                        .param("size", "1")
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("totalElements").value(7))
+                .andExpect(jsonPath("content[0].recordType.type").value("COURSE"))
+                .andExpect(jsonPath("content[0].uid").isNotEmpty());
+        mockMvc.perform(get("/learner_records")
+                        .with(csrf())
+                        .param("resourceId", "course1")
+                        .param("size", "1")
+                        .param("page", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("totalElements").value(7))
+                .andExpect(jsonPath("content[0].recordType.type").value("COURSE"))
+                .andExpect(jsonPath("content[0].uid").isNotEmpty());
+    }
+
+    @Test
     public void testCreateLearnerRecordWithEventsBulk() throws Exception {
         String json = """
                 [


### PR DESCRIPTION
- Fix pagination in Learner record and learner record events
- Order by created timestamp and ID to cover off cases where the timestamps are identical