### PR TITLE
LC-4110 Learning reminder job: Use correct page size when fetching civil servants

### DIFF
--- a/src/main/java/uk/gov/cslearning/record/client/identity/IdentitiesClient.java
+++ b/src/main/java/uk/gov/cslearning/record/client/identity/IdentitiesClient.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.cslearning.record.client.IHttpClient;
 import uk.gov.cslearning.record.domain.identity.Identity;
 
@@ -28,8 +29,8 @@ public class IdentitiesClient implements IIdentitiesClient {
 
     @Override
     public Map<String, Identity> fetchByUids(List<String> uids) {
-        String url = String.format("%s?uids=%s", uidMapUrl, String.join(",", uids));
-        RequestEntity<Void> request = RequestEntity.get(url).build();
+        UriComponentsBuilder uri = UriComponentsBuilder.fromUriString(uidMapUrl).queryParam("uids", String.join(",", uids));
+        RequestEntity<Void> request = RequestEntity.get(uri.build().toUriString()).build();
         return httpClient.executeMapRequest(request, new ParameterizedTypeReference<>() {
         });
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ registry-service:
   getResourceByOrgCodeUrl: "/civilServants/organisation"
   organisationalUnitsUrl: "/v2/organisationalUnits"
   getOrganisationsMaxPageSize: 200
-  getCSUidsMaxPageSize: 5000
+  getCSUidsMaxPageSize: ${REGISTRY_SERVICE_CS_UIDS_MAX_PAGE_SIZE:1000}
 
 catalogue:
   serviceUrl: ${LEARNING_CATALOGUE_SERVICE_URL:http://localhost:9001}

--- a/src/test/java/uk/gov/cslearning/record/service/scheduler/learningJob/LearningJobTest.java
+++ b/src/test/java/uk/gov/cslearning/record/service/scheduler/learningJob/LearningJobTest.java
@@ -123,19 +123,19 @@ public class LearningJobTest extends IntegrationTestBase {
         stubService.getCsrsStubService().getCivilServantsForDepartment("COD", 0, 1, """
                 {"content": ["coCivilServant1"], "totalElements": 2}
                 """);
-        stubService.getCsrsStubService().getCivilServantsForDepartment("COD", 0, 5000, """
+        stubService.getCsrsStubService().getCivilServantsForDepartment("COD", 0, 1000, """
                 {"content": ["coCivilServant1", "coCivilServant2"], "totalElements": 2}
                 """);
         stubService.getCsrsStubService().getCivilServantsForDepartment("DWP", 0, 1, """
                 {"content": ["dwpCivilServant1"], "totalElements": 2}
                 """);
-        stubService.getCsrsStubService().getCivilServantsForDepartment("DWP", 0, 5000, """
+        stubService.getCsrsStubService().getCivilServantsForDepartment("DWP", 0, 1000, """
                 {"content": ["dwpCivilServant1", "dwpCivilServant2"], "totalElements": 2}
                 """);
         stubService.getCsrsStubService().getCivilServantsForDepartment("HMRC", 0, 1, """
                 {"content": ["hmrcCivilServant1"], "totalElements": 2}
                 """);
-        stubService.getCsrsStubService().getCivilServantsForDepartment("HMRC", 0, 5000, """
+        stubService.getCsrsStubService().getCivilServantsForDepartment("HMRC", 0, 1000, """
                 {"content": ["hmrcCivilServant1", "hmrcCivilServant2"], "totalElements": 2}
                 """);
     }


### PR DESCRIPTION
- Set default page size for fetching civil servants to 1000
- Construct identity UID request correctly to avoid spring warning